### PR TITLE
test: mock lucide-react for jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,8 @@ const customJestConfig = {
   // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
   moduleDirectories: ['node_modules', '<rootDir>/'],
   testEnvironment: 'jest-environment-jsdom',
+  // lucide-react is published as an ES module and needs to be transformed for Jest
+  transformIgnorePatterns: ['/node_modules/(?!lucide-react)/'],
 }
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -4,3 +4,15 @@
 // Used for __tests__/testing-library.js
 // Learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom'
+
+// lucide-react publishes ES modules which Jest cannot parse without additional configuration.
+// Mock the library so icons render as basic SVG elements during tests.
+jest.mock('lucide-react', () => {
+  const React = require('react');
+  return new Proxy(
+    {},
+    {
+      get: (target, prop) => (props) => React.createElement('svg', props),
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- transform lucide-react so jest can load its ES modules
- mock lucide-react icons with basic svg elements during tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890011b0f0c832d9e803a013acaa2dc